### PR TITLE
adding promo tile path to strings not sanitized

### DIFF
--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -10,10 +10,19 @@ it.
 import { v4 as uuidv4 } from 'uuid';
 
 import { updateSearchInputCtx, updateSearchResultsCtx } from '../context';
-import {AttributeMetadataResponse, ClientProps, MagentoHeaders, ProductSearchQuery, ProductSearchResponse, PromoTileResponse,RefinedProduct, RefineProductQuery} from '../types/interface';
+import {
+  AttributeMetadataResponse,
+  ClientProps,
+  MagentoHeaders,
+  ProductSearchQuery,
+  ProductSearchResponse,
+  PromoTileResponse,
+  RefinedProduct,
+  RefineProductQuery,
+} from '../types/interface';
 import { SEARCH_UNIT_ID } from '../utils/constants';
 import {
-  ATTRIBUTE_METADATA_QUERY,  
+  ATTRIBUTE_METADATA_QUERY,
   PRODUCT_SEARCH_QUERY,
   REFINE_PRODUCT_QUERY,
 } from './queries';
@@ -173,23 +182,33 @@ const getAttributeMetadata = async ({
   return results?.data;
 };
 
-
 const getCategoryPromoTiles = async ({
   promoTilesDataPath,
   categoryPath,
-}: {promoTilesDataPath: string, categoryPath: string}): Promise<PromoTileResponse[]> => {     
-  try {    
-    const promoTilesJSON = await fetch(promoTilesDataPath).then((res) => res.text());
+}: {
+  promoTilesDataPath: string;
+  categoryPath: string;
+}): Promise<PromoTileResponse[]> => {
+  try {
+    const promoTilesJSON = await fetch(promoTilesDataPath).then((res) =>
+      res.text()
+    );
     const tiles: { data: PromoTileResponse[] } = JSON.parse(promoTilesJSON);
-    return tiles?.data
-      .filter(item => {
-        return (item.path && item.destination && item.image && item.position) 
-          && categoryPath.replace(/^\/|\/$/g, '').toUpperCase()
-            .startsWith(item?.path?.replace(/^\/|\/$/g, '').toUpperCase());
-      });
-  } catch(error) {    
+    return tiles?.data.filter((item) => {
+      return (
+        item.path &&
+        item.destination &&
+        item.image &&
+        item.position &&
+        categoryPath
+          .replace(/^\/|\/$/g, '')
+          .toUpperCase()
+          .startsWith(item?.path?.replace(/^\/|\/$/g, '').toUpperCase())
+      );
+    });
+  } catch (error) {
     return [];
-  }  
+  }
 };
 
 const refineProductSearch = async ({
@@ -231,4 +250,9 @@ const refineProductSearch = async ({
   return results?.data;
 };
 
-export { getAttributeMetadata, getProductSearch, refineProductSearch, getCategoryPromoTiles };
+export {
+  getAttributeMetadata,
+  getProductSearch,
+  refineProductSearch,
+  getCategoryPromoTiles,
+};

--- a/src/context/products.tsx
+++ b/src/context/products.tsx
@@ -10,8 +10,20 @@ it.
 import { createContext } from 'preact';
 import { useContext, useEffect, useMemo, useState } from 'preact/hooks';
 
-import {getCategoryPromoTiles,getProductSearch, refineProductSearch} from '../api/search';
-import {Facet, FacetFilter, PageSizeOption, Product, ProductSearchQuery, PromoTileResponse,RedirectRouteFunc} from '../types/interface';
+import {
+  getCategoryPromoTiles,
+  getProductSearch,
+  refineProductSearch,
+} from '../api/search';
+import {
+  Facet,
+  FacetFilter,
+  PageSizeOption,
+  Product,
+  ProductSearchQuery,
+  PromoTileResponse,
+  RedirectRouteFunc,
+} from '../types/interface';
 import {
   CATEGORY_SORT_DEFAULT,
   DEFAULT_MIN_QUERY_LENGTH,
@@ -259,16 +271,16 @@ const ProductsContextProvider = ({ children }: WithChildrenProps) => {
           categorySearch: !!categoryPath,
         });
 
-        let categoryPromoTiles: PromoTileResponse[] = [];;
-        if (categoryPath && categoryPath.length > 0) {          
+        let categoryPromoTiles: PromoTileResponse[] = [];
+        if (categoryPath && categoryPath.length > 0) {
           categoryPromoTiles = await getCategoryPromoTiles({
             promoTilesDataPath: storeCtx.promoTilesDataPath,
-            categoryPath
+            categoryPath,
           });
           setPromoTiles(categoryPromoTiles);
         }
 
-        setItems(data?.productSearch?.items || []);        
+        setItems(data?.productSearch?.items || []);
         setFacets(data?.productSearch?.facets || []);
         setTotalCount(data?.productSearch?.total_count || 0);
         setTotalPages(data?.productSearch?.page_info?.total_pages || 1);

--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -77,7 +77,12 @@ const StoreContextProvider = ({
         customerGroup: context?.customerGroup ?? '',
         userViewHistory: context?.userViewHistory ?? [],
       },
-      apiUrl: environmentType?.toLowerCase() === 'testing' ? TEST_URL : (apiUrl ? apiUrl : API_URL),
+      apiUrl:
+        environmentType?.toLowerCase() === 'testing'
+          ? TEST_URL
+          : apiUrl
+          ? apiUrl
+          : API_URL,
       promoTilesDataPath,
       apiKey:
         environmentType?.toLowerCase() === 'testing' && !apiKey

--- a/src/utils/validateStoreDetails.ts
+++ b/src/utils/validateStoreDetails.ts
@@ -36,7 +36,7 @@ export const validateStoreDetailsKeys = (
       delete (storeDetails as any)[key];
       return;
     }
-    if (key !== 'apiUrl') {
+    if (key !== 'apiUrl' && key !== 'promoTilesDataPath') {
       (storeDetails as any)[key] = sanitizeString((storeDetails as any)[key]);
     }
   });


### PR DESCRIPTION
Most of the changes in here are actually just auto-linting things.

The one relevant change is in the file at `src/utils/validateStoreDetails.ts` and makes it so the passed in path for the promo tiles is not sanitized (meaning it stays a URL path)